### PR TITLE
referencing github-hosted touchplate widget.

### DIFF
--- a/auto-generated-workspace.html
+++ b/auto-generated-workspace.html
@@ -937,7 +937,7 @@ cpdefine("inline:com-chilipeppr-workspace-grbl", ["chilipeppr_ready"], function(
                         var that = this;
                         chilipeppr.load(
                             "#com-chilipeppr-ws-touchplate",
-                            "http://fiddle.jshell.net/jarret/kvab65ot/show/light/",
+                            "http://raw.githubusercontent.com/johnlauer/widget-grbl-touchplate/master/auto-generated-widget.html",
                             function() {
                                 require(["inline:com-chilipeppr-widget-touchplate"], function(touchPlate) {
                                     that.touchPlateInstance = touchPlate;

--- a/workspace.js
+++ b/workspace.js
@@ -763,7 +763,7 @@ cpdefine("inline:com-chilipeppr-workspace-grbl", ["chilipeppr_ready"], function(
                         var that = this;
                         chilipeppr.load(
                             "#com-chilipeppr-ws-touchplate",
-                            "http://fiddle.jshell.net/jarret/kvab65ot/show/light/",
+                            "http://raw.githubusercontent.com/johnlauer/widget-grbl-touchplate/master/auto-generated-widget.html",
                             function() {
                                 require(["inline:com-chilipeppr-widget-touchplate"], function(touchPlate) {
                                     that.touchPlateInstance = touchPlate;


### PR DESCRIPTION
using same widget as chilipeppr-grbl/workspace-grbl This is untested, and changes need to be populated into auto-generated-workspace.html

There are lots of other jsfiddle URLs which seem to have github replacements in chilipeppr-grbl/workspace-grbl but I'm not familiar enough with what they all do to feel comfortable diving in.